### PR TITLE
added issue template for content outlet

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-outlet.md
+++ b/.github/ISSUE_TEMPLATE/content-outlet.md
@@ -1,0 +1,22 @@
+---
+name: Outlet
+about: Channel or Outlet to share content
+title: Outlet
+labels: outlet
+assignees: ''
+
+---
+
+**Content Outlet**
+
+**Description**
+
+**Type**
+
+- [ ] Blog
+- [ ] Meetup
+- [ ] Conference
+- [ ] Group
+- [ ] Other
+
+**Links and Relevant Resources**


### PR DESCRIPTION
Added an issue template to track new outlets or channels that can be used to share content. Right now we have issue templates for tracking conferences but none for blog, meetup and other outlets.
